### PR TITLE
Fix annotations for overloaded functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ exportToHTML
 .piggy
 pinpoint_piggy
 grammar/*.scm
+
+.DS_Store
+testData/.DS_Store


### PR DESCRIPTION
Resolves: #457 

## Issues with this CR
Converting from a compacted function into an ordinary function still is not working 100%. This is the current behaviour:

```julia
Base.length() = 0

Base.function Base.length()
  return 0
end
```

I cannot find where `Base` is being prepended to `function`. The string for replacing the text can be found [here](https://github.com/mattBrzezinski/julia-intellij/blob/MB/overloaded-function-annotator/src/org/ice1000/julia/lang/editing/julia-annotator.kt#L90), but I'm not seeing where this overload is being written.

## Current Behaviour
Compact function to ordinary function:
```julia
# Original
Base.length() = 0

# After running annotation
Base.function length()
  return 0
end
```

Ordinary function to compact function:
```julia
# Original
function Base.length()
  return 0
end

# After running annotation
length() = 0
```

## Expected Behaviour

```julia
Base.length() = 0

function Base.length()
  return 0
end
```
