### PR TITLE
Skip execution of startup file when checking for Julia envdir

### DIFF
--- a/src/org/ice1000/julia/lang/action/julia-pkg-actions.kt
+++ b/src/org/ice1000/julia/lang/action/julia-pkg-actions.kt
@@ -37,10 +37,10 @@ class JuliaRemovePkgAction(
 				if (beforeVersion07)
 					printJulia(box.comboBox.selectedItem.toString(), 30_000L, """Pkg.rm("$removePackageName")""")
 				else
-					executeCommand(box.comboBox.selectedItem.toString(), """
+					executeCommand(box.comboBox.selectedItem.toString(), input = """
 using Pkg
 Pkg.rm("$removePackageName")
-""", 30_000L)
+""", timeLimit = 30_000L)
 				ApplicationManager.getApplication().invokeLater {
 					Messages.showDialog(
 						project,
@@ -84,11 +84,11 @@ class JuliaAddPkgAction(
 					if (beforeVersion07)
 						printJulia(box.comboBox.selectedItem.toString(), 50_000L, """Pkg.add("$it")""")
 					else
-						executeCommand(box.comboBox.selectedItem.toString(), """
+						executeCommand(box.comboBox.selectedItem.toString(), input = """
 using Pkg
 Pkg.add("$it")
 exit()
-""", 50_000L)
+""", timeLimit = 50_000L)
 				}
 
 				override fun onSuccess() = ApplicationManager.getApplication().invokeLater {

--- a/src/org/ice1000/julia/lang/module/julia-package-manager.kt
+++ b/src/org/ice1000/julia/lang/module/julia-package-manager.kt
@@ -47,7 +47,7 @@ private val packagePredicate = Predicate { dir: Path ->
  */
 @Language("Julia")
 fun versionsList(settings: JuliaSettings) =
-	executeCommand(settings.exePath, "Pkg.installed()", 20_000L)
+	executeCommand(settings.exePath, input = "Pkg.installed()", timeLimit = 20_000L)
 		.first
 		.filter { "=>" in it }
 		.sorted()
@@ -66,7 +66,11 @@ fun loadNamesListByEnvFile(settings: JuliaSettings, envdir: String): List<String
 
 fun getEnvDir(settings: JuliaSettings): String {
 	//language=Julia
-	return executeCommand(settings.exePath, "using Pkg\nPkg.envdir()\nexit()", timeLimit = 4000L)
+	return executeCommand(
+		settings.exePath, "-q", "--startup-file=no", "-E using Pkg;Pkg.envdir()",
+		input = null,
+		timeLimit = 4000L
+	)
 		.first
 		.firstOrNull()
 		.let { it ?: "" }

--- a/src/org/ice1000/julia/lang/utils.kt
+++ b/src/org/ice1000/julia/lang/utils.kt
@@ -34,13 +34,15 @@ fun printJulia(
  * @return (stdout, stderr)
  */
 fun executeJulia(
-	exePath: String, code: String? = null, timeLimit: Long = 2000L, vararg params: String) =
+	exePath: String, code: String? = null, timeLimit: Long = 2000L, vararg params: String
+) =
 	executeCommand(
 		"$exePath ${params.joinToString(" ")}",
-		code?.let { "$it\nexit()" },
-		timeLimit)
+		input = code?.let { "$it\nexit()" },
+		timeLimit = timeLimit
+	)
 
-fun executeCommandToFindPath(command: String) = executeCommand(command, null, 500L)
+fun executeCommandToFindPath(command: String) = executeCommand(command, input = null, timeLimit = 500L)
 	.first
 	.firstOrNull()
 	?.split(' ')
@@ -50,7 +52,11 @@ fun executeCommandToFindPath(command: String) = executeCommand(command, null, 50
 		.firstOrNull(::validateJuliaExe)
 
 fun executeCommand(
-	command: String, input: String? = null, timeLimit: Long = 1200L): Pair<List<String>, List<String>> {
+	vararg command: String,
+	input: String? = null,
+	timeLimit: Long = 1200L
+): Pair<List<String>, List<String>> {
+
 	var processRef: Process? = null
 	var output: List<String> = emptyList()
 	var outputErr: List<String> = emptyList()

--- a/test/org/ice1000/julia/lang/module/julia-sdk-type-test.kt
+++ b/test/org/ice1000/julia/lang/module/julia-sdk-type-test.kt
@@ -4,8 +4,8 @@ import org.ice1000.julia.lang.executeCommand
 
 fun main(args: Array<String>) {
 	if (!System.getenv("CI").isNullOrBlank()) return
-	println(executeCommand("ls", null, 100L).first)
-	println(executeCommand("whereis julia", null, 500L).first)
+	println(executeCommand("ls", input = null, timeLimit = 100L).first)
+	println(executeCommand("whereis julia", input = null, timeLimit = 500L).first)
 	println(juliaPath)
 	println("" in arrayOf(""))
 }

--- a/test/org/ice1000/julia/lang/utils-test.kt
+++ b/test/org/ice1000/julia/lang/utils-test.kt
@@ -40,7 +40,7 @@ class UtilsKtTest {
 	}
 
 	@Test
-	fun whereIsJulia() = executeCommand("whereis julia", null, 1000)
+	fun whereIsJulia() = executeCommand("whereis julia", input = null, timeLimit = 1000)
 		.first
 		.forEach(::println)
 


### PR DESCRIPTION
The change to `getEnvDir()` is implemented using a non interactive call to Julia ( `-E` ) and required a change for `executeCommand` to accept multiple arguments.  